### PR TITLE
Add github-cli skill

### DIFF
--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -25,5 +25,4 @@ gh issue list --state open
 
 ## Troubleshooting
 
-- gh auth loginで認証を行うべきです。認証されていない場合は、gh auth loginを実行させてください
-- Ensure authentication is set up (usually via `GITHUB_TOKEN` environment variable).
+- If you are not authenticated, run `gh auth login`.


### PR DESCRIPTION
Adds a new skill `github-cli` that provides a wrapper for the GitHub CLI (`gh`). This skill instructs the agent to prioritize using `gh` for GitHub interactions over curl or web scraping, addressing issue #1. It includes a `SKILL.md` definition and a `scripts/gh.sh` wrapper script.

---
*PR created automatically by Jules for task [2778594536315584394](https://jules.google.com/task/2778594536315584394) started by @hrdtbs*