### PR TITLE
Add windows-git-bash skill

### DIFF
--- a/skills/windows-git-bash/SKILL.md
+++ b/skills/windows-git-bash/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: windows-git-bash
+description: Verifies and utilizes Git Bash or WSL on Windows to avoid PowerShell compatibility issues.
+---
+
+# Windows Git Bash / WSL Execution
+
+This skill helps ensure that commands are executed within a Bash-compatible environment (Git Bash or WSL) on Windows systems, avoiding common issues associated with PowerShell or Command Prompt.
+
+## How It Works
+
+1.  **Environment Verification**: The agent can run `check-env.sh` to confirm it is operating within Git Bash or WSL.
+2.  **Command Execution**: Once verified, the agent should continue to use the current shell for all subsequent commands, leveraging standard Linux/Unix tools available in Git Bash/WSL.
+
+## Usage
+
+```bash
+bash /mnt/skills/user/windows-git-bash/scripts/check-env.sh
+```
+
+## Output
+
+The script outputs the detected environment type.
+
+**Example Output (Git Bash):**
+```json
+{
+  "environment": "git-bash",
+  "os_type": "msys",
+  "message": "Running in Git Bash / MSYS."
+}
+```
+
+**Example Output (WSL):**
+```json
+{
+  "environment": "wsl",
+  "os_type": "linux-gnu",
+  "message": "Running in WSL."
+}
+```
+
+## Troubleshooting
+
+-   If the script fails to run, ensure `bash` is in the PATH.
+-   If the output indicates "unknown" or "powershell" (unlikely if running via bash), you may need to explicitly launch Git Bash or WSL.

--- a/skills/windows-git-bash/scripts/check-env.sh
+++ b/skills/windows-git-bash/scripts/check-env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Detect environment and output JSON
+echo "Detecting environment..." >&2
+
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+    echo '{"environment": "git-bash", "os_type": "msys", "message": "Running in Git Bash / MSYS."}'
+elif grep -q Microsoft /proc/version 2>/dev/null; then
+    echo '{"environment": "wsl", "os_type": "linux-gnu", "message": "Running in WSL."}'
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    echo '{"environment": "linux", "os_type": "linux-gnu", "message": "Running in Linux."}'
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo '{"environment": "macos", "os_type": "darwin", "message": "Running in macOS."}'
+else
+    echo '{"environment": "unknown", "os_type": "unknown", "message": "Unknown environment."}'
+fi


### PR DESCRIPTION
Implemented `windows-git-bash` skill to address issue #2.
The skill includes a `check-env.sh` script that detects if the environment is Git Bash (msys), WSL, or other Unix-like systems.
The `SKILL.md` provides instructions on how to use this verification to ensure commands are executed in a bash-compatible environment on Windows.

---
*PR created automatically by Jules for task [16359407429977309137](https://jules.google.com/task/16359407429977309137) started by @hrdtbs*