### PR TITLE
Add search-code skill

### DIFF
--- a/skills/search-code/SKILL.md
+++ b/skills/search-code/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: search-code
+description: Efficiently search for code patterns in the current directory using grep. Use this skill when you need to find where a function, variable, or string is defined or used. Triggers on "find code", "search for", "grep".
+---
+
+# Search Code
+
+This skill provides a powerful code search capability using `grep`. It allows agents to quickly locate code definitions, usages, and string occurrences within the project, excluding common non-source directories like `node_modules` and `.git`.
+
+## How It Works
+
+1. The agent invokes the skill with a search pattern (string or regex).
+2. The skill executes a `grep` command recursively in the current directory.
+3. It excludes `node_modules`, `.git`, `dist`, and `build` directories to keep results relevant.
+4. It outputs the file path, line number, and matching content for each occurrence.
+
+## Usage
+
+```bash
+bash /mnt/skills/user/search-code/scripts/search-code.sh "pattern" [path]
+```
+
+**Arguments:**
+- `pattern` - The string or regular expression to search for. Required.
+- `path` - The directory or file to search in. Defaults to `.` (current directory).
+
+**Examples:**
+
+Search for "function main" in the current directory:
+```bash
+bash /mnt/skills/user/search-code/scripts/search-code.sh "function main"
+```
+
+Search for "TODO" in the `src` directory:
+```bash
+bash /mnt/skills/user/search-code/scripts/search-code.sh "TODO" src
+```
+
+## Output
+
+The output is a JSON array of objects, each representing a match.
+
+```json
+[
+  {
+    "file": "src/main.ts",
+    "line": 10,
+    "content": "function main() {"
+  },
+  {
+    "file": "src/utils.ts",
+    "line": 5,
+    "content": "export function helper() {"
+  }
+]
+```
+
+## Present Results to User
+
+When presenting results, format them as a list or table depending on the number of matches.
+
+**Example:**
+
+Found 2 matches for "main":
+
+- `src/main.ts:10`: `function main() {`
+- `src/utils.ts:5`: `export function helper() {` (Note: this example content might not match the query, just illustrating format)
+
+## Troubleshooting
+
+- **No results found**: Try a broader search pattern or check if the path is correct.
+- **Permission denied**: Ensure the script has execution permissions (`chmod +x`).
+- **Pattern errors**: If using regex, ensure special characters are escaped properly.

--- a/skills/search-code/scripts/search-code.sh
+++ b/skills/search-code/scripts/search-code.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+PATTERN="$1"
+SEARCH_PATH="${2:-.}"
+
+if [ -z "$PATTERN" ]; then
+  echo "Error: Search pattern is required." >&2
+  exit 1
+fi
+
+if [ ! -e "$SEARCH_PATH" ]; then
+  echo "Error: Path '$SEARCH_PATH' does not exist." >&2
+  exit 1
+fi
+
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+
+# Run grep. If it returns 0 (found) or 1 (not found), we handle it.
+# If it returns >1 (error), we let set -e fail the script? No, we want to catch it.
+set +e
+grep -rHnIZ --exclude-dir={node_modules,.git,dist,build,coverage} -e "$PATTERN" "$SEARCH_PATH" > "$TMP_FILE"
+GREP_EXIT_CODE=$?
+set -e
+
+if [ $GREP_EXIT_CODE -eq 0 ]; then
+  # Matches found
+  # Use jq to format. We read from TMP_FILE.
+  # We construct JSON array.
+  # We use split("\u0000") to separate filename from line:content (grep -Z output).
+  # Then we split the rest by colon to separate line number from content.
+  # We use tonumber? to safely convert line number, though it should be numeric.
+  jq -R -s 'split("\n") | map(select(length > 0)) | map(split("\u0000")) | map({file: .[0], rest: (.[1]|split(":"))}) | map({file: .file, line: (.rest[0]|tonumber), content: (.rest[1:]|join(":"))})' "$TMP_FILE"
+elif [ $GREP_EXIT_CODE -eq 1 ]; then
+  # No matches found
+  echo "[]"
+else
+  # Error
+  echo "Error running grep. Exit code: $GREP_EXIT_CODE" >&2
+  exit $GREP_EXIT_CODE
+fi

--- a/test_null.txt
+++ b/test_null.txt
@@ -1,0 +1,1 @@
+line1: content


### PR DESCRIPTION
Added a new agent skill `search-code` that allows agents to search for code patterns using `grep` with robust output formatting (JSON) and error handling.
This skill is useful for finding code definitions and usages without direct shell access or complex grep commands.

- `skills/search-code/SKILL.md`: Documentation and usage.
- `skills/search-code/scripts/search-code.sh`: Implementation script using `grep -rHnIZ`.

---
*PR created automatically by Jules for task [14017476626381180390](https://jules.google.com/task/14017476626381180390) started by @hrdtbs*