### PR TITLE
feat: add concise react-best-practices agent skill

### DIFF
--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: react-best-practices
+description: Apply React best practices. Use when writing or refactoring React components.
+---
+
+# React Best Practices
+
+## Directives
+
+* **RSC Default**: Use React Server Components by default. Add `'use client'` strictly when needed.
+* **Colocation**: Keep components, hooks, styles, and tests in the same directory.
+* **Avoid `useEffect`**: Do not use for data fetching, derived state, or orchestrating events.
+* **Composition**: Favor composition (props/children) over Context or Prop Drilling.
+* **Immutability**: Ensure functional state updates.


### PR DESCRIPTION
This PR adds a new agent skill `react-best-practices` to the repository.

As requested by Issue #13, the skill has been written to be "extremely thin" and highly refined. It avoids explaining generic or basic React concepts (such as what React Server Components or hooks are) because modern AI models inherently possess this knowledge. Instead, it provides actionable directives, constraints, and checklists tailored to React development.

The idea for this skill was selected based on the popular skills listed on `skills.sh`, specifically targeting one of the most useful skills (React best practices) but stripping away the fluff to align with the repository's core philosophy.

---
*PR created automatically by Jules for task [11651643834563276976](https://jules.google.com/task/11651643834563276976) started by @hrdtbs*