### PR TITLE
feat(skills): add frontend-design skill

### DIFF
--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use when building or styling web UI to avoid generic AI aesthetics.
+---
+
+* Intentional Direction: Commit to a bold, cohesive aesthetic (e.g., minimalist, maximalist, brutalist, retro, playful).
+* Typography: Use distinctive display fonts paired with refined body fonts. Avoid generic fonts like Inter, Roboto, or Arial.
+* Color & Theme: Use dominant colors with sharp accents via CSS variables. Avoid generic purple gradients on white backgrounds.
+* Motion: Prioritize CSS-only animations (HTML) or Motion (React). Use staggered reveals and high-impact moments over scattered micro-interactions.
+* Spatial Composition: Employ unexpected layouts, asymmetry, or grid-breaking elements. Balance density with negative space.
+* Details: Add depth with gradient meshes, noise textures, geometric patterns, layered transparencies, or custom cursors.


### PR DESCRIPTION
This PR adds a new skill called `frontend-design`. 

Since there were no open issues specifying a skill to create, I followed the prompt's instructions to look at `https://skills.sh/` and find a useful skill to implement. I chose the `frontend-design` skill (which is popular on the leaderboard). 

The prompt instructed me to make the skill "extremely thin and refined" (referencing `react-best-practices`) and to delete knowledge that the AI should already know (e.g. "write clean code"). 

I distilled the long `frontend-design` skill down to its absolute core constraints (e.g., commit to a bold direction, avoid generic fonts/colors, use CSS variables for themes, use structural variations instead of scattered micro-interactions).

---
*PR created automatically by Jules for task [12773465000697556732](https://jules.google.com/task/12773465000697556732) started by @hrdtbs*