### PR TITLE
refactor(skills): restructure api-design-principles skill to focus on flow control

### DIFF
--- a/skills/api-design-principles/SKILL.md
+++ b/skills/api-design-principles/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: api-design-principles
-description: Apply API design principles for REST and GraphQL.
+description: Apply API design principles for REST and GraphQL. Use when designing, creating or modifying API endpoints or schemas.
 ---
 
-* REST: Use plural nouns for resources, always paginate collections, and version APIs explicitly.
-* GraphQL: Follow Schema-First design.
-* GraphQL: Use the Connection pattern (Relay style) for list pagination.
-* GraphQL: Return specific payload types for mutations (include modified object and errors).
-* GraphQL: Prevent N+1 issues by batching requests (e.g., DataLoaders).
+* When working with REST APIs, load and read `references/rest.md`.
+* When working with GraphQL APIs, load and read `references/graphql.md`.

--- a/skills/api-design-principles/references/graphql.md
+++ b/skills/api-design-principles/references/graphql.md
@@ -1,0 +1,6 @@
+# GraphQL API Design Principles
+
+* Follow Schema-First design.
+* Use the Connection pattern (Relay style) for list pagination.
+* Return specific payload types for mutations (include modified object and errors).
+* Prevent N+1 issues by batching requests (e.g., DataLoaders).

--- a/skills/api-design-principles/references/rest.md
+++ b/skills/api-design-principles/references/rest.md
@@ -1,0 +1,5 @@
+# REST API Design Principles
+
+* Use plural nouns for resources.
+* Always paginate collections.
+* Version APIs explicitly.


### PR DESCRIPTION
This PR refactors the `api-design-principles` skill to follow best practices for skill structure. Specifically, it addresses the requirement that `SKILL.md` should focus on flow control and delegate domain knowledge to separate files.

**Changes:**
- Created `skills/api-design-principles/references/rest.md` containing the REST API design guidelines.
- Created `skills/api-design-principles/references/graphql.md` containing the GraphQL design guidelines.
- Updated `skills/api-design-principles/SKILL.md` to remove the inline domain knowledge, replacing it with instructions on when to load and read the respective reference files based on the context (REST or GraphQL).

---
*PR created automatically by Jules for task [2631875707944336021](https://jules.google.com/task/2631875707944336021) started by @hrdtbs*