### PR TITLE
Refactor React Best Practices Skill

### DIFF
--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -3,8 +3,4 @@ name: react-best-practices
 description: Apply React best practices. Use when writing or refactoring React components.
 ---
 
-* RSC Default: Use React Server Components by default. Add `'use client'` strictly when needed.
-* Colocation: Keep components, hooks, styles, and tests in the same directory.
-* Avoid `useEffect`: Do not use for data fetching, derived state, or orchestrating events.
-* Composition: Favor composition (props/children) over Context or Prop Drilling.
-* Immutability: Ensure functional state updates.
+* When writing or refactoring React components, load and read `references/react-guidelines.md`.

--- a/skills/react-best-practices/references/react-guidelines.md
+++ b/skills/react-best-practices/references/react-guidelines.md
@@ -1,0 +1,2 @@
+* RSC Default: Use React Server Components by default. Add `'use client'` strictly when needed.
+* Colocation: Keep components, hooks, styles, and tests in the same directory.


### PR DESCRIPTION
Refactored `skills/react-best-practices/SKILL.md` to act solely as a flow control mechanism. Extracted project-specific domain constraints (RSC Default, Colocation) to `skills/react-best-practices/references/react-guidelines.md` and removed generic React knowledge that AI models already possess.

---
*PR created automatically by Jules for task [5133047281997019703](https://jules.google.com/task/5133047281997019703) started by @hrdtbs*