### PR TITLE
refactor(react-best-practices): align SKILL.md with best practices

### DIFF
--- a/skills/react-best-practices/SKILL.md
+++ b/skills/react-best-practices/SKILL.md
@@ -3,8 +3,4 @@ name: react-best-practices
 description: Apply React best practices. Use when writing or refactoring React components.
 ---
 
-* RSC Default: Use React Server Components by default. Add `'use client'` strictly when needed.
-* Colocation: Keep components, hooks, styles, and tests in the same directory.
-* Avoid `useEffect`: Do not use for data fetching, derived state, or orchestrating events.
-* Composition: Favor composition (props/children) over Context or Prop Drilling.
-* Immutability: Ensure functional state updates.
+* When writing or refactoring React components, load and read `references/conventions.md`.

--- a/skills/react-best-practices/references/conventions.md
+++ b/skills/react-best-practices/references/conventions.md
@@ -1,0 +1,2 @@
+* RSC Default: Use React Server Components by default. Add `'use client'` strictly when needed.
+* Colocation: Keep components, hooks, styles, and tests in the same directory.


### PR DESCRIPTION
This pull request refactors the `react-best-practices` skill to adhere strictly to the skill creation best practices outlined in the anthropic/skills repository.

**Changes made:**
- Created `skills/react-best-practices/references/conventions.md` to store specific project constraints (RSC Default, Colocation).
- Removed generic React best practices (useEffect rules, Composition preference, Immutability) as AI models inherently possess this knowledge.
- Transformed `skills/react-best-practices/SKILL.md` into a pure flow control file that instructs the agent to read `references/conventions.md` when writing or refactoring React components.

---
*PR created automatically by Jules for task [5504291360840604107](https://jules.google.com/task/5504291360840604107) started by @hrdtbs*