### PR TITLE
refactor: update architecture-patterns skill to use references

### DIFF
--- a/skills/architecture-patterns/SKILL.md
+++ b/skills/architecture-patterns/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: architecture-patterns
-description: Apply proven architectural patterns (Clean Architecture, Hexagonal, DDD).
+description: Apply proven architectural patterns (Clean Architecture, Hexagonal, DDD). Use when designing or refactoring system architecture.
 ---
 
-* Clean Architecture: Dependencies flow strictly inward. Inner layers (Entities, Use Cases) must not know outer layers (UI, Database, Frameworks).
-* Hexagonal Architecture: Isolate core logic from external concerns using Input/Output Ports (interfaces) and Adapters (implementations).
-* DDD: Avoid Anemic Domain Models. Entities must encapsulate business rules, not just hold data.
-* Ensure the domain layer is completely free of framework-specific dependencies.
+* When applying architectural patterns, load and read `references/constraints.md` for strict project constraints.

--- a/skills/architecture-patterns/references/constraints.md
+++ b/skills/architecture-patterns/references/constraints.md
@@ -1,0 +1,1 @@
+Ensure the domain layer is completely free of framework-specific dependencies.


### PR DESCRIPTION
Refactors the `architecture-patterns` skill to align with the `skill-creator` best practices. 

- Removed standard LLM knowledge of architecture patterns (Clean Architecture, DDD, etc.).
- Created a separate `references/constraints.md` file for project-specific constraints.
- Updated the `SKILL.md` to be strictly a flow control pointer with YAML frontmatter.

---
*PR created automatically by Jules for task [17531859980578488626](https://jules.google.com/task/17531859980578488626) started by @hrdtbs*