### PR TITLE
refactor(skills): replace negative constraints with positive framing in anti-patterns

### DIFF
--- a/skills/agent-quiz-generator/SKILL.md
+++ b/skills/agent-quiz-generator/SKILL.md
@@ -63,13 +63,13 @@ All output follows the structured communication standard:
 - **Clear evaluation** — When evaluating the answer, explicitly state if it is correct or incorrect.
 - **Explain the *Why*** — Always provide the reasoning behind the correct answer to reinforce learning.
 
-## Anti-Patterns (NEVER Do These)
+## Anti-Patterns
 
-- **NEVER generate questions about syntax trivialities or rote memorization.**
+- **Focus on conceptual questions, not syntax or rote memorization.**
   - *Why*: It's a waste of the user's time. Good questions test conceptual understanding and mental models, not "what is the exact name of the third argument to this function."
-- **NEVER give the answer away in the question prompt.**
+- **Ensure the question requires actual knowledge rather than guessing from the prompt structure.**
   - *Why*: If the user can guess the answer by just reading the structure of the question or options (e.g. one option is super detailed and the others are brief), it doesn't effectively assess learning.
-- **NEVER answer the question for the user in the initial prompt.**
+- **Wait for the user's response before providing the answer.**
   - *Why*: The whole point is to have the subagent ask the question, wait for the user, and then evaluate. If you output the question and the answer in the same response, you defeat the purpose of a quiz.
-- **NEVER use generic "Did you understand?" questions.**
+- **Ask specific, concrete questions that force application of knowledge.**
   - *Why*: Users will almost always reflexively say "Yes." Always ask a specific, concrete question that forces them to apply the knowledge.

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -14,13 +14,13 @@ The GitHub CLI (`gh`) is your primary and ONLY interface for GitHub. The mindset
 - **Authentication First:** Always ensure you are authenticated before attempting complex operations. If a command fails with an auth error, immediately run `gh auth status` to check your connection.
 - **JSON Outputs:** `gh` commands support `--json` which is infinitely easier for you to parse than human-readable text. When you need to read data for further processing, ALWAYS use `--json`.
 
-## 🚫 Anti-Patterns (NEVER Do These)
+## 🚫 Anti-Patterns
 
-- **NEVER use `curl` to fetch from the GitHub API.** `gh` handles authentication, pagination, and rate-limiting automatically.
-- **NEVER attempt to web scrape GitHub.** Do not use `lynx`, `curl`, or python scripts to read `github.com` URLs. Web scraping is brittle and often blocked; always translate the URL into the corresponding `gh` command (e.g., `gh issue view <url>`) to ensure reliability.
-- **NEVER parse human-readable `gh` output when you need structured data.** Human-readable output formats may change. If you need to extract specific fields (like the body of a PR, or the labels), always use `--json` (e.g., `gh pr view 123 --json title,body,state`) for reliable parsing.
-- **NEVER forget to handle pagination.** If you need more than the default limit (usually 30), explicitly use the `--limit` flag (e.g., `--limit 100`) so you do not miss necessary data.
-- **NEVER use interactive commands.** Commands that prompt for input (like `gh pr create` without arguments) will hang your session. Always provide all required arguments upfront.
+- **Always use `gh` instead of `curl` to fetch from the GitHub API.** `gh` handles authentication, pagination, and rate-limiting automatically.
+- **Use `gh` commands instead of web scraping GitHub.** Do not use `lynx`, `curl`, or python scripts to read `github.com` URLs. Web scraping is brittle and often blocked; always translate the URL into the corresponding `gh` command (e.g., `gh issue view <url>`) to ensure reliability.
+- **Always use the `--json` flag for programmatic processing.** Human-readable output formats may change. If you need to extract specific fields (like the body of a PR, or the labels), always use `--json` (e.g., `gh pr view 123 --json title,body,state`) for reliable parsing.
+- **Always handle pagination explicitly using the `--limit` flag.** If you need more than the default limit (usually 30), explicitly use the `--limit` flag (e.g., `--limit 100`) so you do not miss necessary data.
+- **Provide all required arguments upfront to avoid interactive prompts.** Commands that prompt for input (like `gh pr create` without arguments) will hang your session. Always provide all required arguments upfront.
 
 ## 🌳 Decision Tree & Workflows
 


### PR DESCRIPTION
Refactors the Anti-Patterns sections of the `agent-quiz-generator` and `github-cli` skills. Replaces heavy-handed, negative "NEVER" commands with strongly directive, positive framing ("Focus on", "Always use") in accordance with LLM prompt engineering best practices defined in `skill-creator`. This improves compliance by telling the model exactly what to do instead of what not to do.

---
*PR created automatically by Jules for task [16019461567921255790](https://jules.google.com/task/16019461567921255790) started by @hrdtbs*