### PR TITLE
Add anti-patterns to comprehensive-code-reviewer skill

### DIFF
--- a/skills/comprehensive-code-reviewer/SKILL.md
+++ b/skills/comprehensive-code-reviewer/SKILL.md
@@ -39,6 +39,17 @@ Your feedback must be empathetic, constructive, and actionable. Frame your sugge
 **Good:** "It looks like `userId` might be undefined here if the API call fails. Should we add a null check before accessing `userId.profile`?"
 **Bad:** "You forgot to check if `userId` is null. Fix it."
 
+## Anti-Patterns (NEVER Do These)
+
+- **NEVER deliver feedback as harsh commands or personal attacks.**
+  *Why:* Code reviews are collaborative. Demeaning language creates a toxic environment and makes the author defensive, reducing the likelihood of constructive collaboration.
+- **NEVER point out a flaw without offering a concrete recommendation or asking a clarifying question.**
+  *Why:* Saying "This is wrong" without explaining how to fix it leaves the author stuck and wastes time. Always provide a code snippet, a link to documentation, or a specific suggestion.
+- **NEVER prioritize nitpicks (formatting, variable names) over critical architectural or security issues.**
+  *Why:* While style matters, security vulnerabilities and performance bottlenecks are much more critical. Cluttering the review with minor style comments can obscure the important issues.
+- **NEVER rubber-stamp code without understanding its context.**
+  *Why:* "LGTM" without actual review defeats the purpose. If you don't understand what the code does or its impact on the broader system, you cannot verify its correctness or security.
+
 ### Output Format
 
 ALWAYS structure your review using the following markdown format:


### PR DESCRIPTION
Following the best practices for skill creation, an "Anti-Patterns (NEVER Do These)" section has been added to the comprehensive-code-reviewer skill. This provides clear negative constraints and explanations (Why:) to ensure the agent avoids harsh feedback, unhelpful critiques, nitpicking, and rubber-stamping, leading to higher quality code reviews.

---
*PR created automatically by Jules for task [4157636080151193755](https://jules.google.com/task/4157636080151193755) started by @hrdtbs*