### PR TITLE
feat(skills): add web-design skill

### DIFF
--- a/skills/web-design/SKILL.md
+++ b/skills/web-design/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: web-design
+description: "Editorial and design-system web pages with Swiss/International Typographic Style discipline — Müller-Brockmann modular grids, Vignelli Canon tokens, baseline rhythm, optical alignment. Use whenever the user asks for web design, landing page layout, editorial/magazine-style pages, design system, Swiss design, grid overlay, typography hierarchy, or critiques visual hierarchy — even if they don't say \"web design.\" Keywords: grid system, Swiss modernism, editorial layout, baseline grid, Vignelli, Müller-Brockmann, design system, wayfinding."
+---
+
+# Web Design
+
+Swiss/International Typographic Style discipline for the web: rigorous grids, baseline rhythm, objective typography, and verifiable alignment. This skill covers **design judgment, aesthetics, and grid engineering**. For CSS implementation details (responsive escalation, spacing tokens, motion, accessibility), defer to the **css-pro-max** skill.
+
+Adapted from the [Hyperagent public skills](https://github.com/alexmcdonnell-airtable/hyperagent-public-skills) Müller-Brockmann and Vignelli Canon skills.
+
+## Scope
+
+| This skill (web-design) | css-pro-max (implementation) |
+| --- | --- |
+| Style selection (Müller-Brockmann vs Vignelli) | Flex/grid escalation, container queries |
+| Modular grid, baseline lock, optical alignment | Spacing scale, gap vs margin |
+| Type hierarchy philosophy (two sizes, flush-left) | Typography implementation (fluid type, text-wrap, Japanese) |
+| Palette as identifier, anti-patterns | Color tokens, contrast, dark mode |
+| Grid overlay toggle, Puppeteer verification | Animation, focus rings, hit targets, z-index |
+
+## Style selection
+
+```mermaid
+flowchart TD
+  start[Task received] --> q1{Editorial / magazine / report page?}
+  q1 -->|yes| mb[muller-brockmann-grid.md]
+  q1 -->|no| q2{Identity / design system / wayfinding?}
+  q2 -->|yes| vg[vignelli-canon.md]
+  q2 -->|no| q3{General UI polish only?}
+  q3 -->|yes| css[css-pro-max]
+  q3 -->|no| mb
+  mb --> impl[Implement with scripts]
+  vg --> impl
+  impl --> verify[Optional verify_grid.js]
+```
+
+| Brief signal | Open |
+| --- | --- |
+| Magazine spread, longform report, editorial landing page, "show the grid" | [muller-brockmann-grid.md](references/muller-brockmann-grid.md) |
+| Brand/identity system, style guide, transit diagram, wayfinding, "Vignelli-style" | [vignelli-canon.md](references/vignelli-canon.md) |
+| Responsive breakpoints, spacing tokens, motion, a11y audit | **css-pro-max** |
+| Font fallback in headless render, image embedding, Puppeteer setup | [production-notes.md](references/production-notes.md) |
+
+**Sibling styles:** Müller-Brockmann = modular magazine grids + verifiable web engineering. Vignelli = six-typeface canon + identity/wayfinding. When both apply (editorial page with strong identity), start with Müller-Brockmann for grid engineering and borrow Vignelli palette/type rules for tokens.
+
+## Common anti-patterns
+
+- **Decorative grid** — overlay is a full-width sibling of a centered container; columns drift at wide viewports. Fix: overlay inside the same content box (see muller-brockmann-grid §2.2).
+- **Box-on-grid ≠ ink-on-grid** — large display type looks misaligned because glyph side-bearing offsets the visible ink. Fix: runtime optical alignment (§2.6).
+- **"Claude look"** — warm cream background, blue/purple gradients, generic sans hierarchy. Fix: white paper, near-black ink, one accent; hierarchy through scale and white space.
+- **Helvetica → Calibri trap** — headless or rasterized output silently falls back to Noto Sans. Fix: [production-notes.md](references/production-notes.md).
+
+## Loading directives
+
+### Grid / layout symptoms
+
+- **MANDATORY — READ** [muller-brockmann-grid.md](references/muller-brockmann-grid.md) when building editorial pages, grid overlays, baseline-locked layouts, or when alignment looks "off" despite correct CSS grid spans.
+- **Do NOT load** css-pro-max first for grid overlay misalignment; the bug is usually structural (content box mismatch), not a flex/grid choice.
+
+### Identity / system symptoms
+
+- **MANDATORY — READ** [vignelli-canon.md](references/vignelli-canon.md) when designing identity systems, style guides, transit diagrams, or when the brief asks for timeless Swiss-modernist discipline.
+- **Do NOT load** muller-brockmann-grid for pure wayfinding diagram rules; Vignelli transit section is the canonical source.
+
+### Production / verification symptoms
+
+- **MANDATORY — READ** [production-notes.md](references/production-notes.md) when rasterizing SVG/HTML, embedding images in preview iframes, running `verify_grid.js`, or shipping type-critical heroes.
+- **Do NOT skip** font-fidelity checks before trusting headless screenshots or canvas optical measurements.
+
+## Delegation to css-pro-max
+
+After applying design discipline from the references above, open css-pro-max for implementation:
+
+| Design decision | css-pro-max reference |
+| --- | --- |
+| Baseline multiples → spacing implementation | `references/spacing.md` |
+| Grid vs flex for component layout | `references/responsive.md` |
+| Token naming and CSS custom properties | `references/tokens.md` |
+| Font stack, line-height, fluid type, Japanese text | `references/typography.md` |
+| Palette scales, text color hierarchy | `references/color.md` |
+| Focus, contrast, reduced motion | `references/accessibility.md` |
+| Shadows, radii, staggered enters | `references/visual-details.md` |
+
+## Scripts
+
+Run from the skill directory or pass the full path.
+
+### grid_tokens.py — Müller-Brockmann scaffold
+
+```shell
+python3 scripts/grid_tokens.py                         # CSS + JS block
+python3 scripts/grid_tokens.py --scaffold > index.html # full minimal page
+python3 scripts/grid_tokens.py --cols 12 --baseline 8 --gutter 24 --margin 72 --maxw 1296 --accent "#e4002b"
+```
+
+Emits `:root` tokens, subgrid `.band` scaffold, overlay CSS, toggle JS, and optical-alignment JS.
+
+### verify_grid.js — grid verification (optional)
+
+Requires `CHROME` (browser binary) and `PUP` (puppeteer-core module path). If unavailable, use manual overlay inspection — see [production-notes.md](references/production-notes.md).
+
+```shell
+CHROME=/path/to/chrome PUP=/path/to/node_modules/puppeteer-core node scripts/verify_grid.js --widths=1440,1180,900
+```
+
+### vignelli_system.py — Vignelli tokens
+
+```shell
+python3 scripts/vignelli_system.py
+python3 scripts/vignelli_system.py --primary "#F04E23" --format json
+python3 scripts/vignelli_system.py --grid 4x8
+python3 scripts/vignelli_system.py --signage
+```
+
+## Workflow summary
+
+1. Read the style reference (Müller-Brockmann or Vignelli) based on the brief.
+2. Generate scaffold or tokens with the matching script.
+3. Build content on the grid: column-line placement, baseline-locked spacing, objective typography.
+4. Implement CSS details with css-pro-max where needed.
+5. Verify: toggle grid overlay, run `verify_grid.js` if Puppeteer is available, or manual top-left crop inspection.
+6. Check [production-notes.md](references/production-notes.md) before rasterizing or embedding assets.
+
+## Future extensions
+
+The Hyperagent repo also includes brand-book, NYT data-viz, and NYC subway campaign skills. They are not bundled here; add as separate references if needed.
+
+## Attribution
+
+Grid engineering and Vignelli Canon content adapted from [alexmcdonnell-airtable/hyperagent-public-skills](https://github.com/alexmcdonnell-airtable/hyperagent-public-skills) (Müller-Brockmann Grid Systems, Vignelli Canon Design System).

--- a/skills/web-design/references/muller-brockmann-grid.md
+++ b/skills/web-design/references/muller-brockmann-grid.md
@@ -1,0 +1,129 @@
+# Müller-Brockmann Grid Systems — built real, visible, and verified
+
+Josef Müller-Brockmann (1914–1996), Zurich; *Grid Systems in Graphic Design* (1981) is the corpus. The grid is treated as an ethic, not decoration: **"The grid system is an aid, not a guarantee. It permits a number of possible uses and each designer can look for a solution appropriate to his personal style. But one must learn how to use the grid; it is an art that requires practice."** This reference encodes that discipline AND the front-end engineering to make the grid genuinely load-bearing on the web, plus a harness that proves it.
+
+> Two real review notes this reference exists to prevent:
+>
+> 1. *"the grid is just slapped on top and misaligned"* → the overlay wasn't in the same content box as the content (see §2.2).
+> 2. *"the H in the headline is off the grid"* → the headline's BOX was on the grid but its INK wasn't; large glyphs carry a side-bearing (see §2.6). **Box-on-grid ≠ ink-on-grid.**
+
+For CSS implementation details (spacing scale, responsive escalation, accessibility), defer to the **css-pro-max** skill after applying the discipline below.
+
+---
+
+## PART 1 — THE DISCIPLINE (decide before drawing)
+
+- **Objective order.** The grid brings "constructive thought," legibility, and "objective and functional" design. Restraint is the point; the system, not the ego, organizes the page.
+- **Modular grid.** Divide the type area into a field of **modules** — columns AND rows — separated by consistent **gutters**, inside defined **margins**. Text and images occupy whole modules. Müller-Brockmann specimens common field counts (8 / 20 / 32 fields). For the web, a **12-column grid + 8px baseline** is a robust general default; a **6×6 or 4×8 modular field grid** when you want visible rows too.
+- **Baseline grid.** Vertical rhythm is sacred: **leading = a whole multiple of the baseline unit**, and every element snaps to it. This is what makes facing columns and images line up across the page.
+- **Typography.** A **grotesque sans** (Akzidenz-Grotesk / Helvetica; on the web Inter, Helvetica Now, Archivo). **Flush-left, ragged-right.** Few sizes, large jumps in **scale** for hierarchy; objective, not expressive. Big **numerals/data set large** is a signature move.
+- **Palette.** Pure white paper, near-black ink, **one accent — red is canonical**. Avoid the warm-cream "Claude look"; **never blue/purple gradients** (hard house rule).
+- **White space + asymmetry.** Generous margins; asymmetric compositions held in tension by the grid.
+
+---
+
+## PART 2 — MAKE THE GRID REAL ON THE WEB (the load-bearing engineering)
+
+`../scripts/grid_tokens.py` emits this whole scaffold correctly; the rules below are why it's built the way it is.
+
+### 2.1 One source of truth
+
+Put every grid parameter in `:root` CSS variables — `--cols, --gutter, --margin, --bl (baseline), --lh (leading=3×bl), --maxw`. **Content and the overlay both read these same variables.** Never hand-author the overlay separately or it will drift.
+
+### 2.2 The overlay MUST live in the SAME content box as the content ← #1 bug
+
+Failure mode: content sits in a centered `max-width` container while the overlay is a **full-width sibling** of the section. On any viewport wider than `--maxw`, the centered content and the full-width overlay no longer share column positions → "slapped on top / misaligned."
+
+**Fix:** put `.guides` *inside* the same `.wrap`, and draw the column guides with `left/right = var(--margin)` and the **same** `repeat(var(--cols),1fr)` + `column-gap:var(--gutter)`. Then the overlay columns **are** the content columns at every width. Add left/right margin lines at `var(--margin)`.
+
+### 2.3 Place every element by column LINE via subgrid bands
+
+Don't eyeball spans. Each horizontal **band** spans all columns and re-exposes them:
+
+```css
+.band{grid-column:1 / -1; display:grid; grid-template-columns:subgrid; column-gap:var(--gutter); align-items:start;}
+@supports not (grid-template-columns:subgrid){ .band{grid-template-columns:repeat(var(--cols),1fr);} }
+```
+
+Children place with `grid-column: start / end` (e.g. `1 / 6`, `6 / 13`). Every headline, paragraph, photo, caption now snaps to identical lines.
+
+### 2.4 Lock vertical rhythm to the baseline
+
+- Leading = `--lh` (e.g. 24px = 3×8). **Every line-height a multiple of the baseline, in px (not unitless) for display type** — unitless line-heights on large type push the box off the grid.
+- Every margin/padding a multiple of the baseline. Spread top/bottom padding a multiple too, so content starts on a line.
+- **Media heights = multiples of the leading** (e.g. 240/360/432/480px) so a photo's top AND bottom both land on lines.
+- Hairline rules sit inside a baseline-height band, not free-floating.
+
+### 2.5 The toggle (sizzle within the sizzle)
+
+A control (button **+ `G` key**) toggles `body.grid-on`; overlay fades 0→1. Overlay draws: translucent **numbered column fields**, the **baseline** (major line every `--lh`, faint minor every `--bl`), and **margin lines**. Showing the real grid the page is built on IS the demo.
+
+### 2.6 OPTICAL ALIGNMENT — display ink, not its box ← the subtle bug
+
+A 180px headline whose layout box is exactly on line 1 still looks misaligned against body text, because the letterform's **ink** is inset by its **left side-bearing**. Cure at runtime:
+
+```js
+// after document.fonts.ready and on resize:
+var cvs=document.createElement('canvas'),ctx=cvs.getContext('2d');
+document.querySelectorAll('.masthead,.numeral,.shead h2,.h2b').forEach(function(el){
+ el.style.marginLeft='0px';
+ var cs=getComputedStyle(el),ch=(el.textContent||'').trim()[0]; if(!ch) return;
+ if(cs.textTransform==='uppercase') ch=ch.toUpperCase();
+ ctx.font=cs.fontStyle+' '+cs.fontWeight+' '+cs.fontSize+' '+cs.fontFamily; ctx.textAlign='left';
+ var abl=ctx.measureText(ch).actualBoundingBoxLeft; // +ve = ink overhangs left of box
+ if(isFinite(abl)) el.style.marginLeft=abl.toFixed(2)+'px'; // shift box so INK lands on the line
+});
+```
+
+Apply to the masthead, big numerals, and section headlines. It scales with fluid type (re-runs on resize) and uses the **actually-loaded** font, so it's correct in the user's browser.
+
+See [production-notes.md](production-notes.md) for the font-specific measurement caveat and headless verification guidance.
+
+---
+
+## PART 3 — VERIFY (don't trust, measure) → `verify_grid.js`
+
+Render with headless Chrome (Puppeteer) and assert, at **several widths including > and < `--maxw`** (to catch centered-container drift, e.g. 1440 / 1180 / 900):
+
+1. **Column adherence** — every placed `.band > *` left snaps to a column START and right to a column END (~0px). **Exclude the optically-aligned display elements** from this box check (their box is intentionally side-bearing-offset; they're validated in step 4). **Gotcha:** build BOTH the column-start set and the column-end set — a grid item spanning "to line N" ends at the *far* side of the gutter, so single-edge math falsely reports a one-gutter error.
+2. **Overlay match** — each `.guides .col` rect equals the computed column rect (~0px).
+3. **Baseline** — text tops modulo the baseline ≈ 0 (tolerance ≈ half a baseline; the box-top is a proxy — the leading does the real work).
+4. **Optical ink** — each display element's ink-left (box − `actualBoundingBoxLeft`, real font) equals **its own** column line (nearest column-start to its box), not always line 1.
+
+```shell
+CHROME=/path/to/chrome PUP=/path/to/puppeteer-core node ../scripts/verify_grid.js --widths=1440,1180,900
+```
+
+Eyeball a top-left zoom crop (masthead vs body vs column line) — the fastest human check. Full setup and fallback steps: [production-notes.md](production-notes.md).
+
+A clean run looks like: `col=0px overlay=0px baseline≤4px ink=0px` → `GRID VERIFY: PASS`.
+
+---
+
+## PART 4 — CRAFT DEFAULTS (so it looks excellent, not just aligned)
+
+- **Palette:** white `#fff`, ink `#111`, one accent (Swiss red `#e4002b`). No warm-cream Claude look; no blue/purple gradients.
+- **Type:** a real grotesque webfont (Inter / Helvetica Now / Archivo) for display + body; a **mono** (Space Mono / IBM Plex Mono) for folios, captions, grid annotations — reinforces the technical register. Non-Latin via Noto Sans JP etc.
+- **Hierarchy** through scale + weight + white space, not color. Treat key data as **large numerals**. Kicker labels in mono caps. Per-spread folios.
+- **Real photography.** Ground real subjects in real photos. Use project assets or licensed imagery; see [production-notes.md](production-notes.md) for embedding guidance.
+- **Type fidelity if you ever rasterize art:** see [production-notes.md](production-notes.md).
+- **Spread model:** full-width sections, each its own per-spread `.grid` + `.guides`, consistent margins/folios.
+
+---
+
+## PART 5 — WORKFLOW
+
+1. Pick the subject; gather real photos; place assets in the project's public directory.
+2. Generate the scaffold: `python3 ../scripts/grid_tokens.py` (or `--scaffold` for a full page; `--cols/--baseline/--gutter/--margin/--maxw/--accent` to taste; it warns if gutter/margin aren't baseline multiples).
+3. Build spreads as **subgrid bands**; place everything by **column line**; lock spacing/line-heights/media heights to the **baseline**.
+4. Add the overlay (same content box) + toggle + optical-alignment JS (already in the scaffold; point its selector list at your display elements).
+5. Preview in a browser, then **verify** with `verify_grid.js` or manual overlay inspection. Fix and re-check.
+
+## SCRIPTS
+
+- **`../scripts/grid_tokens.py`** — deterministic scaffold generator. Emits the `:root` tokens, `.grid`/`.band` (subgrid) scaffold, `.guides` overlay CSS, toggle JS, and the optical-alignment JS — all wired to one source of truth. `--scaffold` emits a full minimal HTML page. No network/credentials.
+- **`../scripts/verify_grid.js`** — Puppeteer harness implementing all four checks above. Env: `CHROME` (chrome binary), `PUP` (puppeteer-core module path).
+
+## CREED
+
+A grid you can't toggle on and measure is a mood board, not a system. Build it from one source of truth, prove it at 0px, and align the **ink**.

--- a/skills/web-design/references/production-notes.md
+++ b/skills/web-design/references/production-notes.md
@@ -1,0 +1,78 @@
+# Production Notes
+
+Shared hard-won notes for Müller-Brockmann editorial pages and Vignelli Canon design systems. Read when rasterizing artwork, embedding images, running headless verification, or shipping type-critical heroes.
+
+## Type fidelity when rasterizing
+
+Helvetica is not installed in most headless environments. Rasterizing SVG/HTML (cairosvg, headless-Chromium screenshots) with a `Helvetica`/`Arial`/`sans-serif` stack silently falls back to Noto Sans — a rounded humanist face that reads like Calibri and breaks the grotesque. The failure is invisible until someone asks "why does this look like Calibri?"
+
+Fix:
+
+- Render in a true Helvetica/Arial-metric grotesque — Liberation Sans (verify with `fc-match "Liberation Sans:bold"`) or an embedded Helvetica/Arimo TTF.
+- Run `fc-match Helvetica` to reveal the fallback chain.
+- Always eyeball one render before trusting automated output.
+
+The same trap applies to optical-alignment canvas measurement: side-bearing is font-specific. Headless Chrome often lacks the webfont, so canvas falls back to a different grotesque. To verify optics offline, embed the real webfont via `@font-face` (local TTF). In production, runtime JS that measures the loaded font is correct for the user.
+
+## Optical alignment caveat
+
+Large display glyphs carry a left side-bearing: the ink sits inside the layout box, so a headline whose box is on the column line still looks indented against body text. Runtime canvas measurement (see [muller-brockmann-grid.md](muller-brockmann-grid.md) §2.6) must use the actually-loaded font. Wrong font in → wrong nudge out.
+
+## Image embedding
+
+Use project-relative paths or the site's public asset directory (`public/`, `static/`, etc.). Avoid:
+
+- Thread-scoped or authenticated URLs that break in preview iframes or static export.
+- Hotlinking without license or stable hosting.
+
+For local HTML previews, serve via a dev server rather than opening `file://` when modules or CORS matter. For static editorial pages without ES modules, `file://` works for both preview and `verify_grid.js`.
+
+Prefer real photography over generic stock when the brief calls for editorial credibility. Use user-provided assets, licensed sources, or project-owned images.
+
+## Headless grid verification
+
+`verify_grid.js` requires:
+
+- `CHROME` — path to a Chrome/Chromium binary.
+- `PUP` — path to the `puppeteer-core` module (install with `npm install puppeteer-core` in the project, then set `PUP` to that module path).
+
+If `puppeteer-core` is not installed, Node exits with `Cannot find module 'puppeteer-core'`. Use manual verification instead (see below).
+
+On Windows, if `grid_tokens.py --scaffold` fails with `UnicodeEncodeError` on stdout, set `PYTHONIOENCODING=utf-8` or redirect output to a UTF-8 file.
+
+Sandbox Chrome flags that work:
+
+```text
+--headless=new --no-sandbox --disable-gpu --disable-dbus --use-gl=angle --use-angle=swiftshader
+```
+
+If Puppeteer is unavailable, fall back to:
+
+1. Toggle the grid overlay (`G` key) in a browser.
+2. Screenshot a zoom crop of the top-left corner (masthead vs body vs column line).
+3. Check that gutter, margin, and baseline multiples are consistent by inspection.
+
+A clean automated run looks like: `col=0px overlay=0px baseline≤4px ink=0px` → `GRID VERIFY: PASS`.
+
+## Optional code → image workflow
+
+When you need in-situ mockups (signage on a wall, diagram in a station):
+
+1. Draw the type/diagram in code first, in the correct grotesque — the source of truth.
+2. If using an image model, pass the crisp artwork as a reference and name the face explicitly: *Helvetica Bold, Swiss neo-grotesque; NOT Calibri, NOT Noto Sans, NOT a rounded humanist sans.*
+3. If the reference font is wrong, the model reproduces the wrong font — fix the reference before blaming the prompt.
+
+Avoid video generation for type-critical heroes. Most video models drift letterforms frame-to-frame. When type is the hero, deliver stills or screen-capture an interactive webpage.
+
+## Wayfinding-in-context vocabulary (Vignelli)
+
+Useful shot types when documenting transit/wayfinding work:
+
+- Type on the train flank (wordmark + destination blind).
+- Route diagram on the wall (backlit, traveler in silhouette).
+- Paper map in hand by a window.
+- Overhead platform directional (white Helvetica on signal blue).
+- Station ID + square platform flag.
+- Concourse pictogram totem.
+
+Pair each coded design beside its in-context render when the deliverable is a case study.

--- a/skills/web-design/references/vignelli-canon.md
+++ b/skills/web-design/references/vignelli-canon.md
@@ -1,0 +1,106 @@
+# The Vignelli Canon — a working design discipline
+
+Massimo Vignelli (1931–2014), Italian designer mentored by the Castiglioni brothers and Mies van der Rohe ("God is in the details"). With his wife and partner Lella, he designed "from the spoon to the city": the **1972 New York City Subway diagram and signage standards**, the **American Airlines** identity (used ~45 years), **Knoll**, **Bloomingdale's**, **Heller** dinnerware, the **National Park Service Unigrid** system, and the **Grandi Stazioni** Italian railway station signage. His book *The Vignelli Canon* is his own statement of method. This reference is that method, made applyable.
+
+His thesis: **Design is one discipline, above any style. Creativity needs the support of knowledge.** The rules below are a bag of tools, not a cage.
+
+For CSS implementation details (tokens, spacing, color systems, accessibility), defer to the **css-pro-max** skill after applying the discipline below.
+
+---
+
+## PART ONE — THE INTANGIBLES (decide these before you draw anything)
+
+1. **Semantics — search for the meaning first.** Research the subject, its history, market, sender and receiver; distill the *essence*. "Design without semantics is shallow."
+2. **Syntactics — control the relationships.** The grid, typefaces, headline/text/image relationships, page to page. "God is in the details."
+3. **Pragmatics — it must be understood.** It should stand by itself with no explanation. Clarity of intent → clarity of result. "We love complexity but hate complications."
+4. **Discipline.** No sloppiness. "Quality is there or it is not." Self-imposed rules give continuity of intent.
+5. **Appropriateness.** "Listen to what a thing wants to be." The search for the *specific* of the problem — the right media, material, scale, color.
+6. **Ambiguity (the good kind).** A plurality of meanings, used as a spice.
+7. **Design Is One.** Master one discipline and you can design anything; style is downstream of discipline.
+8. **Visual Power.** Strength through contrast of **scale** (huge head vs. small body) and **weight**, never through loudness.
+9. **Intellectual Elegance.** Elegance of the *mind*, not of manners — the opposite of vulgarity.
+10. **Timelessness.** Prefer **primary shapes and primary colors** and typography beyond trends. "Clear, simple and enduring."
+11. **Responsibility.** Three levels: to self, to client (economy of means), to the public.
+12. **Equity.** A long-lived mark is collective culture — **refine it; don't replace it for the sake of change.**
+
+---
+
+## PART TWO — THE TANGIBLES (the concrete rules)
+
+### The Grid — "organization of information"
+
+- The basic structure: organizes content, gives consistency, projects intellectual elegance.
+- "Infinite grids, but just one — the most appropriate — for any problem." Too fine = an empty page; too coarse = restrictive.
+- **Tight outside margins** create tension; **wider margins** bring serenity. **Tight gutters** (~one line of type) so type and images snap to the same grid.
+- The five grids he specimens: **2×4, 5×4, 3×6, 6×6, 4×8** (columns × modules).
+- Paper: prefer the **DIN A series** (golden-rectangle proportions).
+
+### Typography
+
+- **The six basic typefaces for a whole career:** Garamond (1532), Bodoni (1788), Century Expanded (1900), Futura (1930), Times (1931), **Helvetica (1957)**. Plus Optima, Univers, Caslon, Baskerville. *"It is not the type but what you do with it that counts."* Helvetica is the house face.
+- **Type as objective organization, not self-expression.** "I don't believe that when you write *dog* the type should bark." Differentiate with **space, weight, alignment** — not novelty faces.
+- **Alignment: flush left by default.** Centered only for lapidary text/invitations/addresses. **Justified is "fundamentally contrived" — avoid.**
+- **Two type sizes per page, maximum;** heading ≈ **2× body** (e.g., 10/20). Bold/light/roman/italic sparingly and functionally.
+- **Size/leading by column width:** 8/9, 9/10, 10/11 ≤70mm; 12/13, 14/16 ≤140mm; 16/18, 18/20 larger.
+- **Rulers:** **2pt** major, **0.5–1pt** minor; **type hangs from the ruler.**
+
+### Scale, Texture, Color
+
+- **Scale:** the most appropriate size in context — can be pushed deliberately for power. "It doesn't allow mistakes."
+- **Texture:** "Light is the master of form and texture." Shiny reflects, matte absorbs.
+- **Color as Signifier / Identifier ("Chromotype"), not pictorial.** Default to the **primary palette: Red, Blue, Yellow.** In identity, color IS part of the identity.
+
+### White Space — the protagonist
+
+- *"It is really the white that makes the black sing."* *"In a world where everybody screams, silence is noticeable."* Don't fill the page.
+
+### Layout, Sequence, Identity/Diversity, Economy
+
+- A publication is a **cinematic object** — design the *sequence*. **"If you see the layout, it is probably a bad layout."**
+- Balance **identity vs. diversity** — strong system, room to play. Simple modular ratios (single→double→triple). Standardization is an ethic; "good design doesn't cost more than bad design."
+
+---
+
+## TRANSIT & WAYFINDING (Subway + Grandi Stazioni)
+
+- **Route / line diagram:** **45° and 90° only**; **evenly spaced station dots** regardless of true geography; each line a **single color**; **solid dot = always stops, hollow ring = sometimes/passes**; trunk lines share a color; land/water as flat neutral fields; Helvetica throughout.
+- **Station signage (Grandi Stazioni):** **white Helvetica on a signal-blue panel**, flush left; a hierarchy by cap height — station identification (largest, internally lit), directional (overhead, arrow sharing the cap box), information/regulatory (smaller, hanging from a 2pt rule); **platform numbers in a square flag**, double-sided. Arrows and pictograms share the type's cap box.
+- **Pictograms:** geometric, primary-shape based, consistent stroke and cap box; meaning over illustration.
+
+---
+
+## HOW TO APPLY (workflow)
+
+1. **Intangibles pass:** one line each for semantics, appropriateness, and the timelessness/equity stance.
+2. **Pick the system:** one grid, **Helvetica**, **two sizes** (body + ~2× heading), one **primary identifier color**.
+3. **Generate tokens** with `../scripts/vignelli_system.py`.
+4. **Compose** flush-left on the grid; let **white space** carry hierarchy; **rulers** + weight for distinction; **scale contrast** for power.
+5. **Self-critique:** more than two sizes? justified text? decorative color? visible/cluttered layout? novelty face? Cut it.
+
+### Helper script `vignelli_system.py`
+
+Deterministic, no network/credentials.
+
+```shell
+python3 ../scripts/vignelli_system.py                    # CSS tokens
+python3 ../scripts/vignelli_system.py --primary "#F04E23"
+python3 ../scripts/vignelli_system.py --base 16 --format json
+python3 ../scripts/vignelli_system.py --grid 4x8
+python3 ../scripts/vignelli_system.py --signage          # railway panel table
+```
+
+Outputs palette, two-size scale, the five grids, and ruler weights. The CSS `--v-face` lists **"Liberation Sans"** before the generic fallback so headless renders keep a real grotesque — see [production-notes.md](production-notes.md).
+
+### Canon palette (color as identifier)
+
+Vignelli vermilion `#F04E23` · Signal blue `#0039A6` · Signal yellow `#FFCC00` · Ink `#0A0A0A` · Warm paper `#F4F1EA` · White `#FFFFFF`.
+
+---
+
+## PRODUCTION
+
+Rasterization, image embedding, headless font traps, and optional mockup workflows: [production-notes.md](production-notes.md).
+
+### One-line creed
+
+> I love systems and despise happenstance.

--- a/skills/web-design/scripts/grid_tokens.py
+++ b/skills/web-design/scripts/grid_tokens.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+grid_tokens.py — Müller-Brockmann editorial grid scaffold generator.
+
+Emits a battle-tested, self-contained CSS + JS scaffold for building an
+editorial/magazine webpage on a REAL, VISIBLE, VERIFIED modular grid:
+
+  • ONE source of truth: all grid params live in :root CSS variables.
+  • The grid-toggle OVERLAY reads the SAME variables and lives in the SAME
+    content box as the content, so its columns ARE the content columns
+    (this is the fix for the "grid is just slapped on top / misaligned" bug
+    that happens when the overlay is a full-width sibling of a centered
+    max-width container).
+  • Subgrid "bands" so every element is placed by column LINE, not eyeballed.
+  • Vertical rhythm locked to an 8px baseline (24px leading).
+  • Runtime OPTICAL ALIGNMENT: display type is nudged so its INK (not its box)
+    lands on the column line — large letterforms carry a left side-bearing, so
+    a headline whose box is on the grid still looks misaligned vs body text.
+
+No network, no credentials. Deterministic.
+
+Usage:
+  python3 grid_tokens.py                      # print CSS + JS block
+  python3 grid_tokens.py --scaffold           # print a full minimal HTML page
+  python3 grid_tokens.py --cols 12 --baseline 8 --gutter 24 --margin 72 \
+                         --maxw 1296 --accent "#e4002b"
+"""
+import argparse, sys
+
+def build(cfg):
+    c = cfg
+    lh = c.baseline * 3  # leading = 3 baselines
+    css = f""":root{{
+  --cols:{c.cols};
+  --bl:{c.baseline}px;            /* baseline unit */
+  --lh:{lh}px;                    /* leading = 3 x baseline */
+  --gutter:{c.gutter}px;
+  --margin:{c.margin}px;
+  --pad:{c.baseline*12}px;        /* spread top/bottom pad (x baseline) */
+  --maxw:{c.maxw}px;
+
+  --paper:#ffffff;
+  --ink:#111315;
+  --ink-soft:#5b6066;
+  --accent:{c.accent};
+
+  --g-col:rgba(228,0,43,.075);     /* column field fill   (re-tint to taste) */
+  --g-edge:rgba(228,0,43,.40);     /* column edge / margin line */
+  --g-base:rgba(0,150,140,.34);    /* major baseline line ({lh}px) */
+  --g-base-min:rgba(0,150,140,.12);/* minor baseline line ({c.baseline}px)  */
+}}
+*{{box-sizing:border-box;}}
+body{{margin:0;background:var(--paper);color:var(--ink);
+  font-family:"Inter",system-ui,sans-serif;font-size:16px;line-height:var(--lh);
+  -webkit-font-smoothing:antialiased;}}
+img{{display:block;width:100%;height:100%;object-fit:cover;}}
+
+/* ---- spread + grid scaffold (ONE source of truth) ---- */
+.spread{{position:relative;width:100%;}}
+.wrap{{position:relative;max-width:var(--maxw);margin:0 auto;padding:var(--pad) var(--margin);}}
+.grid{{display:grid;grid-template-columns:repeat(var(--cols),1fr);
+  column-gap:var(--gutter);row-gap:var(--lh);}}
+/* a band spans all columns and re-exposes them as a subgrid so children
+   align to the SAME lines as everything else on the page */
+.band{{grid-column:1 / -1;display:grid;grid-template-columns:subgrid;
+  column-gap:var(--gutter);row-gap:var(--lh);align-items:start;}}
+@supports not (grid-template-columns:subgrid){{
+  .band{{grid-template-columns:repeat(var(--cols),1fr);}}
+}}
+/* place children with: style="grid-column: <startline> / <endline>" */
+
+/* ---- the grid OVERLAY (same content box -> columns match exactly) ---- */
+.guides{{position:absolute;inset:0;pointer-events:none;z-index:60;opacity:0;
+  transition:opacity .26s ease;}}
+body.grid-on .guides{{opacity:1;}}
+.guides .cols{{position:absolute;top:0;bottom:0;left:var(--margin);right:var(--margin);
+  display:grid;grid-template-columns:repeat(var(--cols),1fr);column-gap:var(--gutter);}}
+.guides .col{{background:var(--g-col);
+  box-shadow:inset 1px 0 0 var(--g-edge),inset -1px 0 0 var(--g-edge);position:relative;}}
+.guides .col span{{position:absolute;top:{c.baseline*4}px;left:0;right:0;text-align:center;
+  font-family:"Space Mono",monospace;font-size:10px;line-height:1;color:var(--accent);}}
+.guides .rows{{position:absolute;left:var(--margin);right:var(--margin);top:var(--pad);bottom:0;
+  background-image:
+    repeating-linear-gradient(to bottom,var(--g-base) 0 1px,transparent 1px var(--lh)),
+    repeating-linear-gradient(to bottom,var(--g-base-min) 0 1px,transparent 1px var(--bl));}}
+.guides .mline{{position:absolute;top:0;bottom:0;width:1px;background:var(--g-edge);}}
+.guides .mline.l{{left:var(--margin);}} .guides .mline.r{{right:var(--margin);}}
+
+/* ---- vertical rhythm helpers (keep ALL spacing a multiple of --bl) ----
+   line-heights for display type MUST be px multiples of --bl, never unitless,
+   or the box height drifts off the baseline. Media heights = multiples of --lh
+   so photo top AND bottom land on lines. */
+.toggle{{position:fixed;top:18px;right:18px;z-index:200;display:flex;align-items:center;gap:10px;
+  background:var(--ink);color:#fff;border:none;cursor:pointer;font-family:"Space Mono",monospace;
+  font-size:12px;letter-spacing:.14em;text-transform:uppercase;padding:11px 14px;}}
+.toggle .dot{{width:9px;height:9px;border-radius:50%;background:#555;}}
+body.grid-on .toggle{{background:var(--accent);}} body.grid-on .toggle .dot{{background:#fff;}}"""
+
+    js = """/* toggle: button + 'G' key */
+var btn=document.getElementById('gridToggle');
+function setGrid(on){document.body.classList.toggle('grid-on',on);
+  if(btn){btn.setAttribute('aria-pressed',on?'true':'false');
+    var l=btn.querySelector('.lbl'); if(l) l.textContent=on?'Hide grid':'Show grid';}}
+if(btn) btn.addEventListener('click',function(){setGrid(!document.body.classList.contains('grid-on'));});
+document.addEventListener('keydown',function(e){
+  if((e.key==='g'||e.key==='G')&&!e.metaKey&&!e.ctrlKey&&!e.altKey){
+    setGrid(!document.body.classList.contains('grid-on'));}});
+
+/* populate every overlay's column guides (numbered) */
+document.querySelectorAll('.guides .cols').forEach(function(h){
+  var n=getComputedStyle(document.documentElement).getPropertyValue('--cols').trim()||'12';
+  for(var i=1;i<=parseInt(n,10);i++){var c=document.createElement('div');c.className='col';
+    var s=document.createElement('span');s.textContent=i;c.appendChild(s);h.appendChild(c);}});
+
+/* ---- OPTICAL ALIGNMENT --------------------------------------------------
+   Large display glyphs carry a left side-bearing: the ink sits inside the
+   layout box, so a headline whose BOX is on the column line still LOOKS
+   indented (or overhangs) vs body text. Measure each display glyph's actual
+   ink offset and nudge the element so its visible ink lands on the line.
+   Scales with fluid type; re-runs after the webfont loads and on resize.
+   Add the selector list to match your display elements. */
+(function(){
+  var cvs=document.createElement('canvas'),ctx=cvs.getContext('2d');
+  var sel='.masthead, .numeral, .shead h2, .h2b';   /* <-- your display selectors */
+  function align(){
+    document.querySelectorAll(sel).forEach(function(el){
+      el.style.marginLeft='0px';
+      var cs=getComputedStyle(el),ch=(el.textContent||'').trim().charAt(0); if(!ch) return;
+      if(cs.textTransform==='uppercase') ch=ch.toUpperCase();
+      ctx.font=cs.fontStyle+' '+cs.fontWeight+' '+cs.fontSize+' '+cs.fontFamily;
+      ctx.textAlign='left';
+      var abl=ctx.measureText(ch).actualBoundingBoxLeft; /* +ve = ink overhangs left */
+      if(isFinite(abl)) el.style.marginLeft=abl.toFixed(2)+'px'; /* ink -> on the line */
+    });
+  }
+  if(document.fonts&&document.fonts.ready){document.fonts.ready.then(align);}
+  align();
+  var t;window.addEventListener('resize',function(){clearTimeout(t);t=setTimeout(align,120);});
+})();"""
+
+    band = """      <!-- a band: children placed by column LINE -->
+      <div class="band">
+        <div style="grid-column:1 / 6;"><!-- text col --></div>
+        <figure style="grid-column:6 / 13;"><!-- image col (height = x --lh) --></figure>
+      </div>"""
+
+    overlay = """    <div class="guides" aria-hidden="true">
+      <div class="cols"></div><div class="rows"></div>
+      <div class="mline l"></div><div class="mline r"></div>
+    </div>"""
+
+    if cfg.scaffold:
+        return f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Editorial — modular grid</title>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+<style>
+{css}
+</style></head>
+<body>
+<button class="toggle" id="gridToggle" aria-pressed="false"><span class="dot"></span><span class="lbl">Show grid</span></button>
+
+<section class="spread">
+  <div class="wrap">
+    <div class="grid">
+{band}
+    </div>
+{overlay}
+  </div>
+</section>
+
+<script>
+{js}
+</script>
+</body></html>"""
+    else:
+        return ("/* ===== CSS (paste in <style>) ===== */\n" + css +
+                "\n\n/* ===== JS (paste in <script>, after the DOM) ===== */\n" + js +
+                "\n\n/* ===== band markup pattern ===== */\n" + band +
+                "\n\n/* ===== per-spread overlay markup ===== */\n" + overlay + "\n")
+
+def main():
+    ap = argparse.ArgumentParser(description="Müller-Brockmann editorial grid scaffold generator")
+    ap.add_argument("--cols", type=int, default=12)
+    ap.add_argument("--baseline", type=int, default=8, help="baseline unit in px (leading = 3x)")
+    ap.add_argument("--gutter", type=int, default=24)
+    ap.add_argument("--margin", type=int, default=72)
+    ap.add_argument("--maxw", type=int, default=1296)
+    ap.add_argument("--accent", default="#e4002b")
+    ap.add_argument("--scaffold", action="store_true", help="emit a full minimal HTML page")
+    cfg = ap.parse_args()
+    for name, v in (("gutter", cfg.gutter), ("margin", cfg.margin)):
+        if v % cfg.baseline != 0:
+            print(f"# WARNING: --{name} ({v}) is not a multiple of --baseline ({cfg.baseline}); "
+                  f"vertical/spacing rhythm will drift off the grid.", file=sys.stderr)
+    sys.stdout.write(build(cfg) + "\n")
+
+if __name__ == "__main__":
+    main()

--- a/skills/web-design/scripts/verify_grid.js
+++ b/skills/web-design/scripts/verify_grid.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/*
+ * verify_grid.js — prove an editorial page actually sits on its grid.
+ *
+ * Renders the page with headless Chrome (Puppeteer) and asserts, at several
+ * viewport widths (including > and < the content max-width, to catch the
+ * centered-container drift):
+ *
+ *   1. COLUMN ADHERENCE  — every placed `.band > *` element's left edge snaps
+ *      to a column START line and its right edge to a column END line (~0px).
+ *      NB: build BOTH the start-set and end-set of x-coords. A grid item that
+ *      spans "to line N" ends at the FAR side of the gutter, so naive single
+ *      edge math falsely reports a one-gutter (gutter-px) error.
+ *   2. OVERLAY MATCH     — each `.guides .col` rect equals the computed column
+ *      rect (~0px), i.e. the overlay really is the content grid.
+ *   3. BASELINE          — text element tops, modulo the baseline unit, ~0.
+ *   4. OPTICAL INK       — display elements' visible INK-left equals the column
+ *      line (measure canvas actualBoundingBoxLeft with the LOADED font).
+ *      CAVEAT: side-bearing is font-specific. In a sandbox the webfont is often
+ *      absent and canvas falls back to a different grotesque (we measured -16px
+ *      fallback vs -7px real Inter). To verify optics offline, EMBED the real
+ *      webfont via @font-face(local TTF). In production the page's runtime JS
+ *      measures the actually-loaded font, so it is correct for the user.
+ *
+ * Env / args:
+ *   CHROME = path to chrome binary (required)
+ *   PUP    = path to puppeteer-core module (required)
+ *   arg1   = file:// URL or http URL of the page (default: file://$PWD/index.html)
+ *   --widths=1440,1180,900   --baseline=8
+ *
+ * Sandbox chrome flags that work here:
+ *   --no-sandbox --disable-gpu --disable-dbus --use-gl=angle --use-angle=swiftshader
+ * (file:// works for non-ES-module pages; CLI --screenshot can hang on tall
+ *  pages, so we drive via Puppeteer and screenshot per-viewport.)
+ */
+const puppeteer = require(process.env.PUP || 'puppeteer-core');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const url = (args.find(a => !a.startsWith('--'))) ||
+            ('file://' + path.join(process.cwd(), 'index.html'));
+const opt = k => { const a = args.find(x => x.startsWith('--' + k + '=')); return a ? a.split('=')[1] : null; };
+const widths = (opt('widths') || '1440,1180,900').split(',').map(Number);
+const BL = Number(opt('baseline') || 8);
+
+(async () => {
+  const browser = await puppeteer.launch({
+    executablePath: process.env.CHROME, headless: 'new',
+    args: ['--no-sandbox','--disable-gpu','--disable-dbus','--use-gl=angle','--use-angle=swiftshader','--hide-scrollbars']
+  });
+  const page = await browser.newPage();
+  let failed = false;
+
+  for (const W of widths) {
+    await page.setViewport({ width: W, height: 1000, deviceScaleFactor: 1 });
+    await page.goto(url, { waitUntil: 'load', timeout: 25000 });
+    try { await page.evaluate(() => document.fonts && document.fonts.ready); } catch (e) {}
+    await new Promise(r => setTimeout(r, 500));
+
+    const res = await page.evaluate((BL) => {
+      const OPT = '.masthead, .numeral, .shead h2, .h2b'; // display elements: optically aligned by INK, not box
+      const grid = document.querySelector('.grid');
+      const cs = getComputedStyle(grid);
+      const tracks = cs.gridTemplateColumns.split(' ').map(parseFloat);
+      const gap = parseFloat(cs.columnGap);
+      const gr = grid.getBoundingClientRect();
+      // build column START (L) and END (R) coordinate sets
+      const L = [], R = []; let x = gr.left;
+      for (let i = 0; i < tracks.length; i++) { L.push(x); x += tracks[i]; R.push(x); if (i < tracks.length - 1) x += gap; }
+      const nr = (v, arr) => arr.reduce((m, e) => Math.min(m, Math.abs(e - v)), 1e9);
+      const nearest = (v, arr) => arr.reduce((b, e) => Math.abs(e - v) < Math.abs(b - v) ? e : b, arr[0]);
+
+      // 1. column adherence — exclude optical display elements (their box is
+      //    deliberately offset by the glyph side-bearing so the INK lands on
+      //    the line; they are validated by check 4 instead).
+      let colErr = 0, worst = null;
+      document.querySelectorAll('.band > *').forEach(el => {
+        if (el.matches(OPT)) return;
+        const r = el.getBoundingClientRect(); if (r.width < 2) return;
+        const e = Math.max(nr(r.left, L), nr(r.right, R));
+        if (e > colErr) { colErr = e; worst = (el.className || el.tagName).toString().slice(0, 28); }
+      });
+
+      // 2. overlay match
+      let ovErr = 0;
+      document.querySelectorAll('.guides .cols .col').forEach((c, i) => {
+        const r = c.getBoundingClientRect();
+        if (L[i] != null) ovErr = Math.max(ovErr, Math.abs(r.left - L[i]));
+        if (R[i] != null) ovErr = Math.max(ovErr, Math.abs(r.right - R[i]));
+      });
+
+      // 3. baseline (tops modulo BL, per spread relative to its rows-top)
+      let baseErr = 0;
+      document.querySelectorAll('.spread').forEach(sp => {
+        const rowsEl = sp.querySelector('.guides .rows'); if (!rowsEl) return;
+        const top = rowsEl.getBoundingClientRect().top;
+        sp.querySelectorAll('.body,.lede,.cap,.toc li,.dishes li,.kicker').forEach(el => {
+          const t = el.getBoundingClientRect().top - top; const m = ((t % BL) + BL) % BL;
+          baseErr = Math.max(baseErr, Math.min(m, BL - m));
+        });
+      });
+
+      // 4. optical ink offset — each display element's visible INK-left must
+      //    sit on ITS OWN column line (the nearest column-start to its box),
+      //    not always line 1 (headlines can start on any column).
+      const cvs = document.createElement('canvas'), ctx = cvs.getContext('2d');
+      let inkErr = 0, inkWorst = null;
+      document.querySelectorAll(OPT).forEach(el => {
+        const c = getComputedStyle(el); let ch = (el.textContent || '').trim().charAt(0); if (!ch) return;
+        if (c.textTransform === 'uppercase') ch = ch.toUpperCase();
+        ctx.font = c.fontStyle + ' ' + c.fontWeight + ' ' + c.fontSize + ' ' + c.fontFamily; ctx.textAlign = 'left';
+        const abl = ctx.measureText(ch).actualBoundingBoxLeft;
+        const box = el.getBoundingClientRect().left;
+        const target = nearest(box, L);          // the column line this element sits on
+        const ink = box - abl;                    // visible ink-left
+        const e = Math.abs(ink - target);
+        if (e > inkErr) { inkErr = e; inkWorst = (el.className || '').toString().slice(0, 20) + ' "' + ch + '"'; }
+      });
+
+      return {
+        track: +tracks[0].toFixed(1),
+        maxColErrPx: +colErr.toFixed(2), worstCol: worst,
+        overlayErrPx: +ovErr.toFixed(2),
+        maxBaselineOffPx: +baseErr.toFixed(2),
+        maxInkOffPx: +inkErr.toFixed(2), worstInk: inkWorst,
+        fontFamily: getComputedStyle(document.querySelector('.masthead') || document.body).fontFamily.split(',')[0]
+      };
+    }, BL);
+
+    // baseline tolerance = half a baseline unit (element border-box top vs line is a proxy; leading does the real work)
+    const pass = res.maxColErrPx <= 0.5 && res.overlayErrPx <= 0.5 && res.maxBaselineOffPx <= (BL / 2) && res.maxInkOffPx <= 1.0;
+    if (!pass) failed = true;
+    console.log(`[${pass ? 'PASS' : 'FAIL'}] vw=${W}  col=${res.maxColErrPx}px overlay=${res.overlayErrPx}px ` +
+                `baseline=${res.maxBaselineOffPx}px ink=${res.maxInkOffPx}px  ` +
+                `(worstCol=${res.worstCol}, worstInk=${res.worstInk}, font=${res.fontFamily})`);
+  }
+  await browser.close();
+  if (failed) { console.error('GRID VERIFY: FAIL'); process.exit(1); }
+  console.log('GRID VERIFY: PASS');
+})().catch(e => { console.error('ERR', e.message); process.exit(2); });

--- a/skills/web-design/scripts/vignelli_system.py
+++ b/skills/web-design/scripts/vignelli_system.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+vignelli_system.py — Generate a Vignelli-Canon-compliant design-token sheet.
+
+Massimo Vignelli's discipline reduced to machine-emittable tokens: a primary
+palette used as *identifier* (not decoration), a two-size type scale where the
+heading is ~2x the body, the five canonical grids, ruler weights, and the
+signage panel module logic from the Grandi Stazioni railway program.
+
+This is a deterministic generator — no network, no credentials. It exists so the
+"discipline" of the Canon can be applied consistently across artifacts (web
+pages, signage specs, design-system docs) instead of being re-derived by hand
+each time.
+
+Usage:
+  python3 vignelli_system.py                      # default: Helvetica, Vignelli vermilion
+  python3 vignelli_system.py --primary "#F04E23"  # set the identifier color
+  python3 vignelli_system.py --base 16 --format css
+  python3 vignelli_system.py --format json
+  python3 vignelli_system.py --grid 4x8           # print one grid's column/module map
+  python3 vignelli_system.py --signage            # print railway signage panel module table
+
+Formats: css (default) | json | scss
+
+RENDERING NOTE (hard-won): Helvetica is the house face, but it is NOT installed in
+most headless environments. If you rasterize SVG/HTML (cairosvg, headless Chromium)
+with a `Helvetica`/`Arial`/`sans-serif` stack, the renderer silently falls back to
+Noto Sans — a rounded humanist face that reads like Calibri and breaks the Vignelli
+grotesque. For any artwork you will rasterize (or feed to an image model), render in
+a true Helvetica/Arial-metric grotesque: `Liberation Sans` (usually installed) or an
+embedded Helvetica/Arimo TTF. The CSS emitted here lists "Liberation Sans" before the
+generic fallback for exactly this reason. Always eyeball one render before trusting it.
+"""
+
+# Rasterization-safe Helvetica substitute (Arial/Helvetica-metric grotesque).
+RASTER_FONT = "Liberation Sans"
+import argparse, json, sys
+
+# --- The Canon's fixed constants --------------------------------------------
+
+# The six basic typefaces Vignelli said you can live a whole career on.
+BASIC_TYPEFACES = [
+    ("Garamond", 1532, "serif"),
+    ("Bodoni", 1788, "serif"),
+    ("Century Expanded", 1900, "serif"),
+    ("Futura", 1930, "sans-serif"),
+    ("Times", 1931, "serif"),
+    ("Helvetica", 1957, "sans-serif"),
+]
+# plus, by his own admission: Optima, Univers, Caslon, Baskerville.
+
+# Primary palette — color as Signifier / Identifier ("Chromotype"), not pictorial.
+# Vignelli vermilion is the Canon cover; signal blue is the NYC subway / station blue.
+PALETTE = {
+    "vermilion": "#F04E23",   # the Canon cover red — primary identifier
+    "blue":      "#0039A6",   # NYC subway / Grandi Stazioni signage blue
+    "yellow":    "#FFCC00",   # signal yellow
+    "ink":       "#0A0A0A",   # near-black text
+    "paper":     "#F4F1EA",   # warm paper
+    "white":     "#FFFFFF",
+    "rule":      "#0A0A0A",
+}
+
+# The five grids Vignelli specimens in the Canon: (columns, modules).
+GRIDS = {
+    "2x4": (2, 4),
+    "5x4": (5, 4),
+    "3x6": (3, 6),
+    "6x6": (6, 6),
+    "4x8": (4, 8),
+}
+
+# Ruler weights — type ALWAYS hangs from the ruler.
+RULERS = {"major_pt": 2.0, "minor_pt": 1.0, "hair_pt": 0.5}
+
+# Column-width -> size/leading pairs (pt on pt), straight from the Canon.
+TYPE_BY_COLUMN = [
+    ("<=70mm",  [(8, 9), (9, 10), (10, 11)]),
+    ("<=140mm", [(12, 13), (14, 16)]),
+    (">140mm",  [(16, 18), (18, 20)]),
+]
+
+
+def type_scale(base_px: float) -> dict:
+    """Two living sizes per page, heading ~2x body. Everything else is a weight."""
+    body = base_px
+    return {
+        "caption": round(body * 0.75, 2),   # the small print / specs
+        "body":    round(body, 2),          # one of the two sizes
+        "lead":    round(body * 1.5, 2),     # standfirst / intro (use sparingly)
+        "heading": round(body * 2.0, 2),     # the OTHER size — 2x the body
+        "display": round(body * 4.0, 2),     # scale-as-visual-power (covers, hero)
+        "mega":    round(body * 8.0, 2),     # "Books"-spread scale contrast
+        "leading_body": round(body * 1.2, 2),
+        "leading_tight": round(body * 1.05, 2),
+    }
+
+
+def emit_css(primary: str, base: float) -> str:
+    ts = type_scale(base)
+    lines = [":root {",
+             "  /* Vignelli Canon tokens — color as identifier, two sizes, hard grid */"]
+    pal = dict(PALETTE); pal["vermilion"] = primary
+    for k, v in pal.items():
+        lines.append(f"  --v-{k}: {v};")
+    lines.append(f"  --v-primary: {primary};")
+    lines.append("")
+    for k, v in ts.items():
+        unit = "px"
+        lines.append(f"  --v-{k.replace('_','-')}: {v}{unit};")
+    lines.append("")
+    for name, pt in RULERS.items():
+        lines.append(f"  --v-rule-{name.split('_')[0]}: {pt}px;")
+    lines.append("  --v-gutter: 1rem;            /* gutters tight — ~one line of type */")
+    lines.append("  --v-margin: clamp(16px, 4vw, 64px);")
+    # 'Liberation Sans' before the generic fallback so headless renderers don't drift to Noto/Calibri
+    lines.append("  --v-face: 'Helvetica Neue', Helvetica, Arial, 'Liberation Sans', sans-serif;")
+    lines.append("}")
+    lines.append("")
+    lines.append("/* Type hangs FROM the ruler */")
+    lines.append(".v-rule { border-top: var(--v-rule-major) solid var(--v-ink); }")
+    lines.append(".v-rule--minor { border-top: var(--v-rule-minor) solid var(--v-ink); }")
+    lines.append(".v-flush-left { text-align: left; } /* the default; never justify */")
+    lines.append("")
+    for name, (cols, mods) in GRIDS.items():
+        lines.append(f".v-grid-{name} {{ display:grid; "
+                     f"grid-template-columns: repeat({cols}, 1fr); "
+                     f"grid-template-rows: repeat({mods}, 1fr); gap: var(--v-gutter); }}")
+    return "\n".join(lines)
+
+
+def emit_scss(primary: str, base: float) -> str:
+    css = emit_css(primary, base)
+    return "// Vignelli Canon tokens (SCSS map)\n" + css.replace("--v-", "$v-").replace(":root {", "")
+
+
+def emit_json(primary: str, base: float) -> str:
+    pal = dict(PALETTE); pal["vermilion"] = primary; pal["primary"] = primary
+    payload = {
+        "palette": pal,
+        "typefaces_basic": [{"name": n, "year": y, "kind": k} for n, y, k in BASIC_TYPEFACES],
+        "house_face": "Helvetica",
+        "type_scale_px": type_scale(base),
+        "type_by_column": {k: v for k, v in TYPE_BY_COLUMN},
+        "grids": {k: {"columns": c, "modules": m} for k, (c, m) in GRIDS.items()},
+        "rulers_pt": RULERS,
+        "rules": [
+            "Search the meaning before the form (semantics first).",
+            "Max two type sizes per page; heading is ~2x the body.",
+            "Flush left, never justified.",
+            "Color is an identifier, not decoration — primary palette.",
+            "White space makes the black sing — protect the silence.",
+            "If you can see the layout, it is a bad layout.",
+            "Refine equity, don't replace it.",
+            "When rasterizing or feeding art to image models, render Helvetica via Liberation Sans / an embedded TTF — never the bare sans-serif fallback (it becomes Noto/Calibri).",
+        ],
+    }
+    return json.dumps(payload, indent=2)
+
+
+def print_grid(name: str):
+    if name not in GRIDS:
+        print(f"Unknown grid '{name}'. Options: {', '.join(GRIDS)}"); return
+    cols, mods = GRIDS[name]
+    print(f"{name} grid — {cols} columns x {mods} modules")
+    for r in range(mods):
+        print("  " + "  ".join("[]" for _ in range(cols)))
+
+
+def print_signage():
+    """Railway station signage panel module table (Grandi Stazioni logic).
+    Cap-heights scale by a fixed module; arrows and pictograms share the cap box."""
+    print("Railway signage — panel hierarchy (white Helvetica on signal blue)")
+    print(f"  Identifier color: {PALETTE['blue']}   Text/Pictograms: {PALETTE['white']}")
+    rows = [
+        ("Station identification (building)", 600, 100, "Cap height 100mm, internally lit"),
+        ("Directional (overhead)",            300, 75,  "Arrow shares the cap box; flush left"),
+        ("Information / regulatory",          150, 25,  "Hangs from a 2pt rule"),
+        ("Platform number (flag)",            250, 250, "Numeral in a square, double-sided"),
+    ]
+    print(f"  {'Panel':36} {'Panel mm':>9} {'Cap mm':>7}  Note")
+    for name, panel, cap, note in rows:
+        print(f"  {name:36} {panel:>9} {cap:>7}  {note}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generate Vignelli-Canon design tokens.")
+    ap.add_argument("--primary", default=PALETTE["vermilion"], help="identifier color hex")
+    ap.add_argument("--base", type=float, default=16.0, help="base body size in px")
+    ap.add_argument("--format", choices=["css", "scss", "json"], default="css")
+    ap.add_argument("--grid", help="print one grid map, e.g. 4x8")
+    ap.add_argument("--signage", action="store_true", help="print railway signage module table")
+    a = ap.parse_args()
+
+    if a.grid:
+        print_grid(a.grid); return
+    if a.signage:
+        print_signage(); return
+    if a.format == "css":
+        print(emit_css(a.primary, a.base))
+    elif a.format == "scss":
+        print(emit_scss(a.primary, a.base))
+    else:
+        print(emit_json(a.primary, a.base))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add umbrella \web-design\ skill for Swiss/International Typographic Style web design
- Adapt Müller-Brockmann grid systems and Vignelli Canon content from [hyperagent-public-skills](https://github.com/alexmcdonnell-airtable/hyperagent-public-skills)
- Include reference docs (\muller-brockmann-grid.md\, \ignelli-canon.md\, \production-notes.md\) and helper scripts (\grid_tokens.py\, \erify_grid.js\, \ignelli_system.py\)
- Delegate CSS implementation details to the existing \css-pro-max\ skill

## Test plan

- [x] \python scripts/grid_tokens.py --scaffold\ generates HTML (UTF-8 stdout on Windows)
- [x] \python scripts/vignelli_system.py --format json\ outputs valid JSON
- [x] markdownlint passes on all new markdown files
- [x] Hyperagent-specific tool references removed (PublishFilePublicly, etc.)

Made with [Cursor](https://cursor.com)